### PR TITLE
Use innerHTML for firefox support

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = function(label, text) {
 
   // otherwise, create a style element
   styleEl = document.createElement('style');
-  styleEl.innerText = text;
+  styleEl.innerHTML = text;
 
   // insert the style element, in order or preference
   // 1. before the first style related element in the page


### PR DESCRIPTION
Using `.innerText` does not work in my local Firefox. `.innerHTML` does (also tested in Chrome and Safari)
